### PR TITLE
change to stream9 #10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
 RUN dnf install --best --refresh -y \
       git \


### PR DESCRIPTION
Hey @mkumatag 

Fixes: https://github.com/ppc64le-cloud/debug-net/issues/10

Hope this helps...

Successfully generates an image

```
podman build -f Dockerfile .
[root@api.policy.cp.fyre.ibm.com ppc64le-cloud-debug-net]# podman images
REPOSITORY                                             TAG             IMAGE ID      CREATED             SIZE
<none>                                                 <none>          2a17030c9754  About a minute ago  446 MB
```

Runs successfully

```
podman run -it 2a17030c9754 /bin/bash
[root@api.policy.cp.fyre.ibm.com ~]# podman run -it 2a17030c9754 /bin/bash
[root@348419a11c92 /]# which network-snapshot.sh
/usr/local/bin/network-snapshot.sh
```

Thanks

Paul